### PR TITLE
管理者機能、フィルタ、scope

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,5 @@ gem 'slim-rails'
 gem 'html2slim'
 gem 'bootstrap'
 
+gem 'rails_autolink'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_autolink (1.1.6)
+      rails (> 3.1)
     railties (6.0.2.2)
       actionpack (= 6.0.2.2)
       activesupport (= 6.0.2.2)
@@ -231,6 +233,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.1)
+  rails_autolink
   sass-rails (>= 6)
   selenium-webdriver
   slim-rails

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,10 +1,10 @@
 class TasksController < ApplicationController
+  before_action :set_task, only: [:show, :edit, :update, :destroy]
   def index
-    @tasks = current_user.tasks
+    @tasks = current_user.tasks.order(created_at: :desc)
   end
 
   def show
-    @task = current_user.tasks.find(params[:id])
   end
 
   def create
@@ -22,23 +22,24 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = current_user.tasks.find(params[:id])
   end
 
   def update
-    task = current_user.tasks.find(params[:id])
-    task.update!(task_params)
-    redirect_to task_url, notice: "タスク「＃{task..nam}」を更新しました。"
+    @task.update!(task_params)
+    redirect_to task_url, notice: "タスク「#{@task.name}」を更新しました。"
   end
 
   def destroy
-    task = current_user.tasks.find(params[:id])
-    task.destroy
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
+    @task.destroy
+    redirect_to tasks_url, notice: "タスク「#{@task.name}」を削除しました。"
   end
   private
 
   def task_params
     params.require(:task).permit(:name,:description)
+  end
+
+  def set_task
+    @task = current_user.tasks.find(params[:id])
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,6 +7,7 @@ class Task < ApplicationRecord
 
   belongs_to :user
 
+  scope :recent, -> { order(created_at: :desc) }
   private
 
   #def set_nameless_name

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -12,7 +12,7 @@ table.table.table-hover
       td= @task.name
     tr
       th= Task.human_attribute_name(:description)
-      td= simple_format(h(@task.description), {} , sanitize: false, wrapper_tag: "div")
+      td= auto_link(simple_format(h(@task.description), {} , sanitize: false, wrapper_tag: "div"))
     tr
       th= Task.human_attribute_name(:created_at)
       td= @task.created_at


### PR DESCRIPTION
#what　
管理者ユーザーの作成、ユーザー一覧ページの権限制限
set_taskを使って同じコードの省略
scopeを使ってタスクの一覧を並べ替え
#why
一般ユーザーが管理機能にアクセスできないようにするため
コードの省略をして見やすいコードに
タスク一覧の並べ替えを行い、見やすい順序にするため
