### PR TITLE
登録確認画面実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,11 +10,21 @@ class TasksController < ApplicationController
   def create
     @task = current_user.tasks.new(task_params)
 
+    if params[:back].present?
+      render :new
+      return
+    end
+
     if @task.save
       redirect_to @task,notice: "タスク「#{@task.name}」を登録しました。"
     else
       render :new
     end
+  end
+
+  def confirm_new
+    @task = current_user.tasks.new(task_params)
+    render :new unless @task.valid?
   end
 
   def new

--- a/app/views/tasks/confirm_new.html.slim
+++ b/app/views/tasks/confirm_new.html.slim
@@ -1,0 +1,15 @@
+h1 登録内容の確認
+
+= form_with model: @task, local: true do |f|
+  table.table.table-hover
+    tbody
+      tr
+        th= Task.human_attribute_name(:name)
+        td= @task.name
+        = f.hidden_field :name
+      tr
+        th= Task.human_attribute_name(:description)
+        td= simple_format(@task.description)
+        = f.hidden_field :description
+  = f.submit '戻る', name: 'back', class: 'btn btn-secondary mr-3'
+  = f.submit '登録', class: 'btn btn-primary'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -3,5 +3,17 @@ h1 タスクの新規登録
 .nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
+- if @task.errors.present?
+  ul#error_explanation
+    - @task.errors.full_messages.each do |message|
+    li= message
 
-= render partial: 'form', locals: { task: @task }
+
+= form_with model: @task, local: true, url: confirm_new_task_path do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :descriotion, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit '確認', class: 'btn btn-primary'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
     resources :users
   end
   root to: 'tasks#index'
-  resources  :tasks
+  resources  :tasks do
+    post :confirm, action: :confirm_new, on: :new
+  end
 end


### PR DESCRIPTION
＃what
タスク登録確認画面の実装
＃why
登録時に間違いを確認するため
